### PR TITLE
feat: add Redguard AG, Bern as Universe patron

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,11 @@ export const PATRONS: Array<Patron> = [
     category: Category.Universe,
   },
   {
+    name: "Redguard AG, Bern",
+    href: "https://www.redguard.ch/",
+    category: Category.Universe,
+  },
+  {
     name: "Codeblock GmbH",
     href: "https://www.linkedin.com/company/codeblock-gmbh/",
     owner: "Claude Gex",


### PR DESCRIPTION
## Summary

Adds **Redguard AG, Bern** (https://www.redguard.ch/) as a new patron in the **Universe** category.

## Changes

- `src/config.ts`: new `PATRONS` entry with `category: Category.Universe`, grouped with the existing Universe patrons (avega IT AG, Peak Scale GmbH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)