### PR TITLE
Membership: eindeutige Formular-Werte + Spec für Live-Patrons-Seite

### DIFF
--- a/src/pages/membership.astro
+++ b/src/pages/membership.astro
@@ -53,7 +53,7 @@ import Footer from "@components/Footer.astro";
             <input
               type="radio"
               name="membership-type"
-              value="basic"
+              value="Mitglied (CHF 32)"
               class="mr-2"
             />
             <span class="text-md">Basic Membership</span>: 32 CHF per year
@@ -65,7 +65,7 @@ import Footer from "@components/Footer.astro";
             <input
               type="radio"
               name="membership-type"
-              value="advanced"
+              value="The Answer (CHF 42)"
               class="mr-2"
             />
             <!-- prettier-ignore -->
@@ -81,7 +81,7 @@ import Footer from "@components/Footer.astro";
             <input
               type="radio"
               name="membership-type"
-              value="category-life"
+              value="Goenner Life (CHF 100)"
               class="mr-2"
             />
             <span class="text-md">Category.LIFE</span>: starting from 128 CHF
@@ -95,7 +95,7 @@ import Footer from "@components/Footer.astro";
             <input
               type="radio"
               name="membership-type"
-              value="category-universe"
+              value="Goenner Universe (CHF 500)"
               class="mr-2"
             />
             <span class="text-md">Category.UNIVERSE</span>: starting from 512
@@ -108,7 +108,7 @@ import Footer from "@components/Footer.astro";
             <input
               type="radio"
               name="membership-type"
-              value="category-everything"
+              value="Goenner Everything (CHF 1000)"
               class="mr-2"
             />
             <span class="text-md">Category.EVERYTHING</span>: starting from


### PR DESCRIPTION
## Was ist drin

Zwei Dinge rund um die Mitgliedschaften:

### 1. Fix am Membership-Formular (`src/pages/membership.astro`)

Die Netlify-Formular-Mail zeigte bisher nur kryptische Radio-Werte (z. B. `advanced`) — dadurch war nachträglich nicht klar, um welches Abo es ging (v. a. bei «advanced»). Die versteckten `value`-Attribute enthalten jetzt den Abo-Namen + exakten Betrag. **Die sichtbaren Labels bleiben unverändert.**

| vorher (`value`) | nachher (`value`) |
|---|---|
| `basic` | `Mitglied (CHF 32)` |
| `advanced` | `The Answer (CHF 42)` |
| `category-life` | `Goenner Life (CHF 100)` |
| `category-universe` | `Goenner Universe (CHF 500)` |
| `category-everything` | `Goenner Everything (CHF 1000)` |

Die Werte entsprechen 1:1 den Abo-Typen in der Vereinsverwaltung, die Zuordnung einer eingehenden Mail ist damit eindeutig.

### 2. Spec: Live-Patrons-Seite (`patrons-live-spec.txt`)

Vorschlag, `/patrons` künftig **live** aus der Vereinsverwaltung guild.plaintext.ch zu speisen statt aus dem handgepflegten `PATRONS`-Array in `src/config.ts` (das gegenüber der realen Mitgliederliste driftet). Ordentliche Mitglieder (32 CHF) bleiben unsichtbar, Gönner (Life/Universe/Everything) und «The Answer» erscheinen.

Die Spec enthält: Typ→Kategorie-Mapping, Architektur-Optionen (build-time vs. öffentlicher Live-Endpoint), den nötigen public JSON-Endpoint, Datenschutz-Regeln (Opt-in per Tag) und die offenen Entscheidungen.

## Bitte um Review / Entscheidung

@schlpbch — Teil 1 (der Fix) ist unabhängig direkt mergebar. Für Teil 2 (Spec) brauchts noch deinen Entscheid zu ein paar Punkten:

- Architektur: build-time (SSG) oder öffentlicher Live-Endpoint?
- «Sponsor»-Stufe: eigene Kategorie, Teil von Everything, oder gar nicht?
- Everything-Grid: Logos beibehalten oder auf Namen umstellen?
- Firmen-Links (`href`) + Ansprechpartner (`owner`): Backend-Felder ergänzen oder Frontend-Mapping?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LevgsBEmSMd4CX83e2EiRY
